### PR TITLE
Sort SQL upgrade script versions numerically

### DIFF
--- a/install_kuali_coeus
+++ b/install_kuali_coeus
@@ -478,7 +478,7 @@ function exec_sql_scripts() {
 	echo
 	if [ "$mysql_or_oracle" -eq "1" ]; then
 		cd ${MYSQL_SQL_FILES_FOLDER}
-		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq ) )
+		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq | sort -n) )
 		for version in ${INSTALL_SQL_VERSION[@]:${1}}
 		do
 			# INSTALL THE MYSQL FILES
@@ -511,7 +511,7 @@ function exec_sql_scripts() {
 		fi
 	elif [ "$mysql_or_oracle" -eq "2" ]; then
 		cd ${ORACLE_SQL_FILES_FOLDER}
-		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq ) )
+		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq | sort -n) )
 		for version in ${INSTALL_SQL_VERSION[@]:${1}}
 		do
 			# INSTALL THE MYSQL FILES


### PR DESCRIPTION
Sort SQL upgrade script versions by their numeric value instead of as text strings to ensure SQL upgrade scripts are applied in correct sequence (version 001, 300, 301... 601, 602, 1505, 1506, 1507, etc).